### PR TITLE
update lava

### DIFF
--- a/demo/cubes.cpp
+++ b/demo/cubes.cpp
@@ -25,9 +25,9 @@ struct instance_data {
 
 int main(int argc, char* argv[]) {
     frame_config config;
-    config.app = "lava raytracing cubes";
+    config.info.app_name = "lava raytracing cubes";
     config.cmd_line = { argc, argv };
-    config.app_info.req_api_version = instance::api_version::v1_1;
+    config.info.req_api_version = api_version::v1_1;
 
     app app(config);
 


### PR DESCRIPTION
Just an update to latest lava...

---

Interesting warning that was already before the update:

```bash
14>------ Build started: Project: lava-extras.raytracing, Configuration: Release x64 ------
14>Building Custom Rule C:/code/thelavablock_lava-rt/liblava-extras/CMakeLists.txt
14>acceleration_structure.cpp
14>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.28.29910\include\functional(13,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
14>C:\code\thelavablock_lava-rt\ext\liblava\liblava/core/types.hpp(9,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
14>C:\code\thelavablock_lava-rt\ext\liblava\liblava/core/math.hpp(7,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
14>C:\code\thelavablock_lava-rt\ext\liblava\liblava/base/base.hpp(7,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
14>C:\code\thelavablock_lava-rt\ext\liblava\liblava/base/memory.hpp(9,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
14>C:\code\thelavablock_lava-rt\ext\liblava\liblava/base/device_table.hpp(7,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
14>C:\code\thelavablock_lava-rt\ext\liblava\liblava/base/device.hpp(7,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
14>C:\code\thelavablock_lava-rt\liblava-extras\liblava-extras/raytracing/acceleration_structure.hpp(4,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
14>C:\code\thelavablock_lava-rt\liblava-extras\liblava-extras\raytracing\acceleration_structure.cpp(2,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
```