### PR TITLE
fix compilation on GNU Linux

### DIFF
--- a/demo/cubes.cpp
+++ b/demo/cubes.cpp
@@ -309,13 +309,13 @@ int main(int argc, char* argv[]) {
         top_as = make_top_level_acceleration_structure();
 
         // buffer data, common to all BLAS
-        VkAccelerationStructureGeometryTrianglesDataKHR triangles = { .sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_TRIANGLES_DATA_KHR,
-                                                                      .vertexFormat = VK_FORMAT_R32G32B32_SFLOAT,
-                                                                      .vertexData = { vertex_buffer->get_address() },
-                                                                      .vertexStride = sizeof(vertex),
-                                                                      .maxVertex = uint32_t(vertices.size()),
-                                                                      .indexType = VK_INDEX_TYPE_UINT32,
-                                                                      .indexData = { index_buffer->get_address() } };
+        const VkAccelerationStructureGeometryTrianglesDataKHR triangles = { .sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_TRIANGLES_DATA_KHR,
+                                                                            .vertexFormat = VK_FORMAT_R32G32B32_SFLOAT,
+                                                                            .vertexData = { vertex_buffer->get_address() },
+                                                                            .vertexStride = sizeof(vertex),
+                                                                            .maxVertex = uint32_t(vertices.size()),
+                                                                            .indexType = VK_INDEX_TYPE_UINT32,
+                                                                            .indexData = { index_buffer->get_address() } };
 
         VkDeviceSize scratch_buffer_size = 0;
 

--- a/demo/cubes.cpp
+++ b/demo/cubes.cpp
@@ -310,12 +310,12 @@ int main(int argc, char* argv[]) {
 
         // buffer data, common to all BLAS
         VkAccelerationStructureGeometryTrianglesDataKHR triangles = { .sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_TRIANGLES_DATA_KHR,
-                                                                        .vertexFormat = VK_FORMAT_R32G32B32_SFLOAT,
-                                                                        .vertexStride = sizeof(vertex),
-                                                                        .maxVertex = uint32_t(vertices.size()),
-                                                                        .indexType = VK_INDEX_TYPE_UINT32 };
-        triangles.vertexData.deviceAddress = vertex_buffer->get_address();
-        triangles.indexData.deviceAddress = index_buffer->get_address();
+                                                                      .vertexFormat = VK_FORMAT_R32G32B32_SFLOAT,
+                                                                      .vertexData = { vertex_buffer->get_address() },
+                                                                      .vertexStride = sizeof(vertex),
+                                                                      .maxVertex = uint32_t(vertices.size()),
+                                                                      .indexType = VK_INDEX_TYPE_UINT32,
+                                                                      .indexData = { index_buffer->get_address() } };
 
         VkDeviceSize scratch_buffer_size = 0;
 

--- a/liblava-extras/CMakeLists.txt
+++ b/liblava-extras/CMakeLists.txt
@@ -37,9 +37,5 @@ target_link_libraries(lava-extras.raytracing PUBLIC
         lava-extras::core
         )
 
-if (CMAKE_COMPILER_IS_GNUCXX)
-        target_compile_options(lava-extras.raytracing PUBLIC -fpermissive)
-endif()
-
 set_property(TARGET lava-extras.raytracing PROPERTY EXPORT_NAME raytracing)
 add_library(lava-extras::raytracing ALIAS lava-extras.raytracing)

--- a/liblava-extras/CMakeLists.txt
+++ b/liblava-extras/CMakeLists.txt
@@ -37,5 +37,9 @@ target_link_libraries(lava-extras.raytracing PUBLIC
         lava-extras::core
         )
 
+if (CMAKE_COMPILER_IS_GNUCXX)
+        target_compile_options(lava-extras.raytracing PUBLIC -fpermissive)
+endif()
+
 set_property(TARGET lava-extras.raytracing PROPERTY EXPORT_NAME raytracing)
 add_library(lava-extras::raytracing ALIAS lava-extras.raytracing)

--- a/liblava-extras/liblava-extras/raytracing/shader_binding_table.hpp
+++ b/liblava-extras/liblava-extras/raytracing/shader_binding_table.hpp
@@ -108,12 +108,12 @@ namespace lava {
                     }
 
                     const size_t possible_padding = rt_properties.shaderGroupBaseAlignment - 1;
-                    buffer = make_buffer();
-                    if (!buffer->create_mapped(device, nullptr, table_data.size() + possible_padding, VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT))
+                    sbt_buffer = make_buffer();
+                    if (!sbt_buffer->create_mapped(device, nullptr, table_data.size() + possible_padding, VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT))
                         return false;
-                    const VkDeviceAddress buffer_address = buffer->get_address();
+                    const VkDeviceAddress buffer_address = sbt_buffer->get_address();
 
-                    uint8_t* buffer_data = static_cast<uint8_t*>(buffer->get_mapped_data());
+                    uint8_t* buffer_data = static_cast<uint8_t*>(sbt_buffer->get_mapped_data());
                     size_t buffer_offset = align_up<VkDeviceAddress>(buffer_address, rt_properties.shaderGroupBaseAlignment) - buffer_address;
 
                     memcpy(&buffer_data[buffer_offset], table_data.data(), table_data.size());
@@ -133,8 +133,8 @@ namespace lava {
                 }
 
                 void destroy() {
-                    if (buffer)
-                        buffer->destroy();
+                    if (sbt_buffer)
+                        sbt_buffer->destroy();
                     device = nullptr;
                 }
 
@@ -143,7 +143,7 @@ namespace lava {
                 }
 
                 bool valid() const {
-                    return buffer && buffer->valid();
+                    return sbt_buffer && sbt_buffer->valid();
                 }
 
                 // miss/hit/callable shader can be chosen in traceRayEXT calls inside shaders with a parameter
@@ -170,7 +170,7 @@ namespace lava {
 
             private:
                 device_ptr device = nullptr;
-                buffer::ptr buffer;
+                buffer::ptr sbt_buffer;
 
                 enum group_type : size_t {
                     raygen = 0,


### PR DESCRIPTION
I've added the ``-fpermissive`` flag to g++ compilation to turn a compiler error into a warning, I specified the scope of ``lava::index`` in the cubes demo to fix ambiguity errors in g++, and I changed the way that two particular ``VkAccelerationStructureGeometryTrianglesDataKHR`` fields are initialized (which appears to have been outdated).